### PR TITLE
Add VELOCITAS_PROJECT_TOKEN organization secret

### DIFF
--- a/otterdog/eclipse-velocitas.jsonnet
+++ b/otterdog/eclipse-velocitas.jsonnet
@@ -17,6 +17,9 @@ orgs.newOrg('eclipse-velocitas') {
     orgs.newOrgSecret('GITLAB_API_TOKEN') {
       value: "pass:bots/automotive.velocitas/gitlab.eclipse.org/api-token",
     },
+    orgs.newOrgSecret('VELOCITAS_PROJECT_TOKEN') {
+      value: "pass:bots/automotive.velocitas/github.com/project-token",
+    },
   ],
   _repositories+:: [
     orgs.newRepo('.github') {


### PR DESCRIPTION
This adds an organizational secret with name VELOCITAS_PROJECT_TOKEN with the following scopes:

- gist
- project
- read:org
- repo
- workflow